### PR TITLE
Remind command updated with contest-id and time to hh:mm:ss format

### DIFF
--- a/cogs/commands.py
+++ b/cogs/commands.py
@@ -49,31 +49,34 @@ class Commands(commands.Cog):
 
 
     @commands.command(name = 'remind')
-    async def remind_contest(self, ctx, when_to_remind = 95000, id=None):
+    async def remind_contest(self, ctx, id=None, when_to_remind = "0:0:0"):
         '''Reminds you about the contest you asked a reminder for
-        Usage: -remind
-        -remind [hours:mins:secs]
-        Example: -remind
-        -remind 3
-        -remind 3:12
-        -remind 3:4:19
+        Usage: -remind id
+        -remind id [hours:mins:secs]
+        Example: -remind 1442
+        -remind 1433 3
+        -remind 1444 3:12
+        -remind 1454 3:4:19
+
+        The contest id can be found out by doing cfnext or from the automatic notifications in the channel.
         '''
-        # time_list = str(when_to_remind).split(':')
-        # h = int(time_list[0])
-        # m = int(time_list[1])
-        # s = int(time_list[2])
-        # when_to_remind = (h*60*60)+(m*60)+(s)
+
+        time_list = str(when_to_remind).split(':')
+        h = int(time_list[0]) if len(time_list) == 1 else 0
+        m = int(time_list[1]) if(len(time_list) == 2) else 0
+        s = int(time_list[2]) if(len(time_list) == 3) else 0
+        when_to_remind = (h*60*60)+(m*60)+(s)
 
         c = cf.Codeforces(self.api_url)
-        contest = c.get_contests()[0]
+        contest = c.find_contest(id)
         print(contest)
 
-        # if(when_to_remind > abs(contest['relativeTimeSeconds'])):
-        #     await ctx.author.send('Oops looks like contest would have begun before the mentioned time')
-        # elif(m>60 or s>60):
-        #     await ctx.author.send('Oops you might want to check time once more')            
-        # else:
-        await asyncio.sleep(contest['relativeTimeSeconds']*(-1) - when_to_remind)
+        if(when_to_remind > abs(contest['relativeTimeSeconds'])):
+            await ctx.author.send('Oops looks like contest would have begun before the mentioned time')
+        elif(m>60 or s>60):
+            await ctx.author.send('Oops you might want to check time once more')            
+        else:
+            await asyncio.sleep(contest['relativeTimeSeconds']*(-1) - when_to_remind)
 
         title="Codeforces Contest Reminder"
         description="Contest begins in {0}".format(time.strftime("%H hours, %M minutes, %S seconds",
@@ -87,7 +90,6 @@ class Commands(commands.Cog):
         embed = a.get_embed()
 
         await ctx.author.send(embed=embed)
-
 
 def setup(bot):
     bot.add_cog(Commands(bot))

--- a/utils/cf.py
+++ b/utils/cf.py
@@ -21,6 +21,14 @@ class Codeforces:
         self.contests = sorted(self.contests, key = lambda i: i['startTimeSeconds'])
         return self.contests
 
+    #Returns the contest object corresponding to the given id.
+    def find_contest(self, id):
+        contest_list = self.get_contests()
+        for c in contest_list:
+            if(str(c['id']) == str(id)):
+                return c
+        return None
+
     # Notification is sent 48 hrs before the event date on the channel.
     # This method just returns the valid list of contests which are eligible for notifications
     def get_valid_contests(self, contest_list):


### PR DESCRIPTION
 Partially solves: #4 

Usage of the remind command changed to:  -remind id [hours:mins:secs]
Implementation: It selects the id from the list of contests and sets a reminder for that!

Yet to be done: Using buttons to set reminders.